### PR TITLE
Websocket update - Spectators and Players

### DIFF
--- a/app/assets/less/main.less
+++ b/app/assets/less/main.less
@@ -8,4 +8,5 @@
 // View styles
 @import "./views/about.less";
 @import "./views/gladiators.less";
+@import "./views/modal.less";
 @import "./views/navbar.less";

--- a/app/assets/less/views/modal.less
+++ b/app/assets/less/views/modal.less
@@ -1,0 +1,18 @@
+.modal {
+    .modal-header {
+        justify-content: center;
+    }
+    .avatar {
+        height: 5rem;
+        width: 5rem;
+        border-radius: 10px;
+        background-repeat: no-repeat;
+        background-position: center;
+    }
+    &.player-one .avatar {
+        background-image: url("/assets/images/board/temple.png");
+    }
+    &.player-two .avatar {
+        background-image: url("/assets/images/board/colloseum.png");
+    }
+}

--- a/app/assets/less/views/modal.less
+++ b/app/assets/less/views/modal.less
@@ -2,6 +2,9 @@
     .modal-header {
         justify-content: center;
     }
+    .modal-dialog {
+        top: 30%;
+    }
     .avatar {
         height: 5rem;
         width: 5rem;

--- a/app/controllers/GladiatorsController.scala
+++ b/app/controllers/GladiatorsController.scala
@@ -44,8 +44,8 @@ class GladiatorsController @Inject() (cc: ControllerComponents) (implicit system
     val configuration = Configuration(5, 15)
     val controller = Controller(configuration)
     // todo: We need to initialize players to call boardToString
-    controller.namePlayerOne("one")
-    controller.namePlayerTwo("two")
+   // controller.namePlayerOne("one")
+   // controller.namePlayerTwo("two")
 
     val jsonNotACommandError: Events = Events.ErrorMessage("Command could not be parsed")
 
@@ -89,8 +89,14 @@ class GladiatorsController @Inject() (cc: ControllerComponents) (implicit system
     def socket = WebSocket.accept[JsValue, JsValue] { request =>
         ActorFlow.actorRef { out =>
             controller.gameState match {
-                case NamingPlayerOne | NamingPlayerTwo => Props(GladiatorWebSocketActor(out, controller))
-                case _ => Props(SpectatorWebSocketActor(out, controller))
+                case NamingPlayerOne | NamingPlayerTwo => {
+                    println("connecting player")
+                    Props(GladiatorWebSocketActor(out, controller))
+                }
+                case _ => {
+                    println("connecting spectator")
+                    Props(SpectatorWebSocketActor(out, controller))
+                }
             }
         }
     }

--- a/app/controllers/GladiatorsController.scala
+++ b/app/controllers/GladiatorsController.scala
@@ -10,6 +10,8 @@ import scala.util.Try
 import de.htwg.se.gladiators.aview.Tui
 import de.htwg.se.gladiators.controller.BaseImplementation.Controller
 import de.htwg.se.gladiators.controller.BaseImplementation.ControllerJson._
+import de.htwg.se.gladiators.controller.GameState.NamingPlayerOne
+import de.htwg.se.gladiators.controller.GameState.NamingPlayerTwo
 import de.htwg.se.gladiators.controller.GameState.TurnPlayerOne
 import de.htwg.se.gladiators.controller.GameState.TurnPlayerTwo
 import de.htwg.se.gladiators.util.Configuration
@@ -20,6 +22,8 @@ import de.htwg.se.gladiators.util.json.CommandJson._
 import de.htwg.se.gladiators.util.json.CoordinateJson._
 import de.htwg.se.gladiators.util.json.EventsJson._
 
+import _root_.controllers.WebSockets.GladiatorWebSocketActor
+import _root_.controllers.WebSockets.SpectatorWebSocketActor
 import akka.actor.ActorSystem
 import akka.actor._
 import akka.http.scaladsl.model.HttpHeader
@@ -34,10 +38,6 @@ import play.api.libs.json._
 import play.api.libs.streams.ActorFlow
 import play.api.mvc.WebSocket.MessageFlowTransformer
 import play.api.mvc._
-import _root_.controllers.WebSockets.SpectatorWebSocketActor
-import _root_.controllers.WebSockets.GladiatorWebSocketActor
-import de.htwg.se.gladiators.controller.GameState.NamingPlayerOne
-import de.htwg.se.gladiators.controller.GameState.NamingPlayerTwo
 
 @Singleton
 class GladiatorsController @Inject() (cc: ControllerComponents) (implicit system: ActorSystem, mat: Materializer) extends AbstractController(cc) {

--- a/app/controllers/GladiatorsController.scala
+++ b/app/controllers/GladiatorsController.scala
@@ -47,7 +47,6 @@ class GladiatorsController @Inject() (cc: ControllerComponents) (implicit system
     controller.namePlayerOne("one")
     controller.namePlayerTwo("two")
 
-    val couldNotParseJsonError: Events = Events.ErrorMessage("Body does not contain valid json")
     val jsonNotACommandError: Events = Events.ErrorMessage("Command could not be parsed")
 
     def about = Action {
@@ -66,13 +65,8 @@ class GladiatorsController @Inject() (cc: ControllerComponents) (implicit system
             readCommand(request.body) match {
                 case Failure(exception) => BadRequest(Json.toJson(jsonNotACommandError))
                 case Success(command) => controller.inputCommand(command) match {
-                    case ErrorMessage(message) => {
-                        val event: Events = ErrorMessage(message)
-                        BadRequest(Json.toJson(event))
-                    }
-                    case event: Events => {
-                        Ok(Json.toJson(controller, event))
-                    }
+                    case message: ErrorMessage => BadRequest(Json.toJson(message: Events))
+                    case event: Events => Ok(Json.toJson(controller, event))
                 }
             }
         }
@@ -88,10 +82,7 @@ class GladiatorsController @Inject() (cc: ControllerComponents) (implicit system
                 )
                 Ok(Json.toJson(controller, gladiatorInfo))
             }
-            case Failure(_) => {
-                val event: Events = jsonNotACommandError
-                BadRequest(Json.toJson(event))
-            }
+            case Failure(_) => BadRequest(Json.toJson(jsonNotACommandError))
         }
     }
 

--- a/app/controllers/WebSockets/GladiatorWebSocketActor.scala
+++ b/app/controllers/WebSockets/GladiatorWebSocketActor.scala
@@ -1,0 +1,63 @@
+package controllers.WebSockets
+
+import de.htwg.se.gladiators.controller.BaseImplementation.Controller
+import de.htwg.se.gladiators.controller.BaseImplementation.ControllerJson._
+import de.htwg.se.gladiators.util.Events
+import de.htwg.se.gladiators.util.json.CommandJson._
+import de.htwg.se.gladiators.util.json.CoordinateJson._
+import de.htwg.se.gladiators.util.json.EventsJson._
+import de.htwg.se.gladiators.util.json.CommandJson._
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import play.api.libs.json._
+import scala.util.Failure
+import de.htwg.se.gladiators.util.Events
+import de.htwg.se.gladiators.util.Events._
+import scala.util.Success
+import de.htwg.se.gladiators.util.Command._
+import de.htwg.se.gladiators.util.Command
+import de.htwg.se.gladiators.model.Player
+import java.util.concurrent.atomic.AtomicReference
+
+case class GladiatorWebSocketActor(out: ActorRef, controller: Controller) extends WebSocketsTrait {
+    listenTo(controller)
+    reactions += { case event: Events => sendJson(controller, event) }
+
+    var player: Option[Player] = None
+
+    override def receive: Actor.Receive = {
+        case msg: JsValue => {
+            out ! (readCommand(msg) match {
+                case Failure(exception) => Json.toJson(ErrorMessage("Could not parse command"): Events)
+                case Success(parsedCommand) => (parsedCommand, player) match {
+                    case (NamePlayerOne(name), None) => controller.namePlayerOne(name) match {
+                        case named: PlayerOneNamed => {
+                            player = controller.playerOne
+                            Json.toJson(named: Events)
+                        }
+                        case message: ErrorMessage => Json.toJson(message: Events)
+                        case _ => Json.toJson(ErrorMessage("Internal Server Error"): Events)
+                    }
+                    case (NamePlayerTwo(name), None) => controller.namePlayerTwo(name) match {
+                        case named: PlayerTwoNamed => {
+                            player = controller.playerTwo
+                            Json.toJson(named: Events)
+                        }
+                        case message: ErrorMessage => Json.toJson(message: Events)
+                        case _ => Json.toJson(ErrorMessage("Internal Server Error"): Events)
+                    }
+
+                    case (move: Move, player: Option[Player]) if controller.currentPlayer == player => Json.toJson(controller.inputCommand(move))
+                    case (Move(_, _), None) => Json.toJson(ErrorMessage("It is not your turn"): Events)
+
+                    case (buyUnit: BuyUnit, player: Option[Player]) if controller.currentPlayer == player => Json.toJson(controller.inputCommand(buyUnit))
+                    case (BuyUnit(_, _), None) => Json.toJson(ErrorMessage("It is not your turn"): Events)
+
+                    case (command: Command, _) => Json.toJson(controller.inputCommand(command))
+                }
+            })
+        }
+    }
+    override def sendJson(controller: Controller, event: Events): Unit = out ! (Json.toJson(controller, event))
+}

--- a/app/controllers/WebSockets/GladiatorWebSocketActor.scala
+++ b/app/controllers/WebSockets/GladiatorWebSocketActor.scala
@@ -60,4 +60,8 @@ case class GladiatorWebSocketActor(out: ActorRef, controller: Controller) extend
         }
     }
     override def sendJson(controller: Controller, event: Events): Unit = out ! (Json.toJson(controller, event))
+    @throws[Exception](classOf[Exception])
+    override def postStop(): Unit = {
+        println("Quitting game")
+    }
 }

--- a/app/controllers/WebSockets/GladiatorWebSocketActor.scala
+++ b/app/controllers/WebSockets/GladiatorWebSocketActor.scala
@@ -1,25 +1,25 @@
 package controllers.WebSockets
 
+import scala.util.Failure
+import scala.util.Success
+
 import de.htwg.se.gladiators.controller.BaseImplementation.Controller
 import de.htwg.se.gladiators.controller.BaseImplementation.ControllerJson._
+import de.htwg.se.gladiators.model.Player
+import de.htwg.se.gladiators.util.Command
+import de.htwg.se.gladiators.util.Command._
 import de.htwg.se.gladiators.util.Events
+import de.htwg.se.gladiators.util.Events._
+import de.htwg.se.gladiators.util.json.CommandJson._
 import de.htwg.se.gladiators.util.json.CommandJson._
 import de.htwg.se.gladiators.util.json.CoordinateJson._
 import de.htwg.se.gladiators.util.json.EventsJson._
-import de.htwg.se.gladiators.util.json.CommandJson._
 
 import akka.actor.Actor
 import akka.actor.ActorRef
-import play.api.libs.json._
-import scala.util.Failure
-import de.htwg.se.gladiators.util.Events
-import de.htwg.se.gladiators.util.Events._
-import scala.util.Success
-import de.htwg.se.gladiators.util.Command._
-import de.htwg.se.gladiators.util.Command
-import de.htwg.se.gladiators.model.Player
 import java.util.concurrent.atomic.AtomicReference
-
+import play.api.libs.json._
+import play.api.mvc.Results.BadRequest
 case class GladiatorWebSocketActor(out: ActorRef, controller: Controller) extends WebSocketsTrait {
     listenTo(controller)
     reactions += { case event: Events => sendJson(controller, event) }

--- a/app/controllers/WebSockets/GladiatorWebSocketActor.scala
+++ b/app/controllers/WebSockets/GladiatorWebSocketActor.scala
@@ -29,30 +29,30 @@ case class GladiatorWebSocketActor(out: ActorRef, controller: Controller) extend
     override def receive: Actor.Receive = {
         case msg: JsValue => {
             out ! (readCommand(msg) match {
-                case Failure(exception) => Json.toJson(ErrorMessage("Could not parse command"): Events)
+                case Failure(exception) => BadRequest(Json.toJson(ErrorMessage("Could not parse command"): Events))
                 case Success(parsedCommand) => (parsedCommand, player) match {
                     case (NamePlayerOne(name), None) => controller.namePlayerOne(name) match {
                         case named: PlayerOneNamed => {
                             player = controller.playerOne
                             Json.toJson(named: Events)
                         }
-                        case message: ErrorMessage => Json.toJson(message: Events)
-                        case _ => Json.toJson(ErrorMessage("Internal Server Error"): Events)
+                        case message: ErrorMessage => BadRequest(Json.toJson(message: Events))
+                        case _ => BadRequest(Json.toJson(ErrorMessage("Internal Server Error"): Events))
                     }
                     case (NamePlayerTwo(name), None) => controller.namePlayerTwo(name) match {
                         case named: PlayerTwoNamed => {
                             player = controller.playerTwo
                             Json.toJson(named: Events)
                         }
-                        case message: ErrorMessage => Json.toJson(message: Events)
-                        case _ => Json.toJson(ErrorMessage("Internal Server Error"): Events)
+                        case message: ErrorMessage => BadRequest(Json.toJson(message: Events))
+                        case _ => BadRequest(Json.toJson(ErrorMessage("Internal Server Error"): Events))
                     }
 
                     case (move: Move, player: Option[Player]) if controller.currentPlayer == player => Json.toJson(controller.inputCommand(move))
-                    case (Move(_, _), None) => Json.toJson(ErrorMessage("It is not your turn"): Events)
+                    case (Move(_, _), None) => BadRequest(Json.toJson(ErrorMessage("It is not your turn"): Events))
 
                     case (buyUnit: BuyUnit, player: Option[Player]) if controller.currentPlayer == player => Json.toJson(controller.inputCommand(buyUnit))
-                    case (BuyUnit(_, _), None) => Json.toJson(ErrorMessage("It is not your turn"): Events)
+                    case (BuyUnit(_, _), None) => BadRequest(Json.toJson(ErrorMessage("It is not your turn"): Events))
 
                     case (command: Command, _) => Json.toJson(controller.inputCommand(command))
                 }

--- a/app/controllers/WebSockets/GladiatorWebSocketActor.scala
+++ b/app/controllers/WebSockets/GladiatorWebSocketActor.scala
@@ -57,6 +57,6 @@ case class GladiatorWebSocketActor(out: ActorRef, controller: Controller) extend
 
     @throws[Exception](classOf[Exception])
     override def postStop(): Unit = {
-        println("Connection closed")
+        println("Player disconnected")
     }
 }

--- a/app/controllers/WebSockets/GladiatorWebSocketActor.scala
+++ b/app/controllers/WebSockets/GladiatorWebSocketActor.scala
@@ -37,18 +37,17 @@ case class GladiatorWebSocketActor(out: ActorRef, controller: Controller) extend
                         case _ => out ! Json.toJson(controller, ErrorMessage("Internal Server Error"): Events)
                     }
                     case (NamePlayerTwo(name), None) => controller.namePlayerTwo(name) match {
-                        case named: PlayerTwoNamed => player = controller.playerTwo
+                        case named: Turn => { player = controller.playerTwo }
                         case message: ErrorMessage => out ! Json.toJson(controller, message: Events)
                         case _ => out ! Json.toJson(controller, ErrorMessage("Internal Server Error"): Events)
                     }
-                    
-                    case (move: Move, player: Option[Player]) if controller.currentPlayer == player => Json.toJson(controller, controller.inputCommand(move): Events)
-                    case (Move(_, _), None) => Json.toJson(controller, ErrorMessage("It is not your turn"): Events)
-
-                    case (buyUnit: BuyUnit, player: Option[Player]) if controller.currentPlayer == player => Json.toJson(controller.inputCommand(buyUnit))
-                    case (BuyUnit(_, _), None) => Json.toJson(controller, ErrorMessage("It is not your turn"): Events)
-
-                    case (command: Command, _) => Json.toJson(controller, controller.inputCommand(command))
+                    case (command: Command, player: Option[Player]) => {
+                        if (controller.currentPlayer.get.id == player.get.id) {
+                            out ! Json.toJson(controller, controller.inputCommand(command))
+                        } else {
+                            out ! Json.toJson(controller, ErrorMessage("It is not your turn"): Events)
+                        }
+                    }
                 }
             }
         }

--- a/app/controllers/WebSockets/SpectatorWebSocketActor.scala
+++ b/app/controllers/WebSockets/SpectatorWebSocketActor.scala
@@ -7,8 +7,8 @@ import de.htwg.se.gladiators.util.Events.ErrorMessage
 import de.htwg.se.gladiators.util.json.EventsJson._
 
 import akka.actor.Actor
-import play.api.libs.json.Json
 import akka.actor.ActorRef
+import play.api.libs.json.Json
 
 case class SpectatorWebSocketActor(out: ActorRef, controller: Controller) extends WebSocketsTrait {
     listenTo(controller)

--- a/app/controllers/WebSockets/SpectatorWebSocketActor.scala
+++ b/app/controllers/WebSockets/SpectatorWebSocketActor.scala
@@ -1,0 +1,19 @@
+package controllers.WebSockets
+
+import de.htwg.se.gladiators.controller.BaseImplementation.Controller
+import de.htwg.se.gladiators.controller.BaseImplementation.ControllerJson._
+import de.htwg.se.gladiators.util.Events
+import de.htwg.se.gladiators.util.Events.ErrorMessage
+import de.htwg.se.gladiators.util.json.EventsJson._
+
+import akka.actor.Actor
+import play.api.libs.json.Json
+import akka.actor.ActorRef
+
+case class SpectatorWebSocketActor(out: ActorRef, controller: Controller) extends WebSocketsTrait {
+    listenTo(controller)
+    reactions += { case event: Events => sendJson(controller, event) }
+
+    override def receive: Actor.Receive = { case _ => Json.toJson(ErrorMessage("Spectators cannot enter commands"): Events)}
+    override def sendJson(controller: Controller, event: Events): Unit = Json.toJson(controller, event)
+}

--- a/app/controllers/WebSockets/SpectatorWebSocketActor.scala
+++ b/app/controllers/WebSockets/SpectatorWebSocketActor.scala
@@ -14,6 +14,6 @@ case class SpectatorWebSocketActor(out: ActorRef, controller: Controller) extend
     listenTo(controller)
     reactions += { case event: Events => sendJson(controller, event) }
 
-    override def receive: Actor.Receive = { case _ => Json.toJson(ErrorMessage("Spectators cannot enter commands"): Events)}
-    override def sendJson(controller: Controller, event: Events): Unit = Json.toJson(controller, event)
+    override def receive: Actor.Receive = { case _ => out ! Json.toJson(controller, ErrorMessage("Spectators cannot enter commands"): Events)}
+    override def sendJson(controller: Controller, event: Events): Unit = out ! Json.toJson(controller, event)
 }

--- a/app/controllers/WebSockets/WebSocketsTrait.scala
+++ b/app/controllers/WebSockets/WebSocketsTrait.scala
@@ -1,9 +1,11 @@
 package controllers.WebSockets
 
+import scala.swing.Reactor
+
 import de.htwg.se.gladiators.controller.BaseImplementation.Controller
 import de.htwg.se.gladiators.util.Events
+
 import akka.actor.Actor
-import scala.swing.Reactor
 
 trait WebSocketsTrait extends Actor with Reactor {
     def sendJson(controller: Controller, event: Events): Unit

--- a/app/controllers/WebSockets/WebSocketsTrait.scala
+++ b/app/controllers/WebSockets/WebSocketsTrait.scala
@@ -1,0 +1,10 @@
+package controllers.WebSockets
+
+import de.htwg.se.gladiators.controller.BaseImplementation.Controller
+import de.htwg.se.gladiators.util.Events
+import akka.actor.Actor
+import scala.swing.Reactor
+
+trait WebSocketsTrait extends Actor with Reactor {
+    def sendJson(controller: Controller, event: Events): Unit
+}

--- a/app/views/gladiators.scala.html
+++ b/app/views/gladiators.scala.html
@@ -13,29 +13,65 @@
                     <div class="playerinfo player1">
                         <div class="playerinfo-row">
                             <div>Name:</div>
-                            <div>@{controller.playerOne.get.name}</div>
+                            <div id="idPlayer1Name">
+                                @{if (controller.playerOne) {
+                                    controller.playerOne.get.name
+                                } else {
+                                    "-"
+                                }
+                            }</div>
                         </div>
                         <div class="playerinfo-row">
                             <div>Base:</div>
-                            <div id="idPlayer1Health">@{controller.playerOne.get.health}</div>
+                            <div id="idPlayer1Health">
+                                @{if (controller.playerOne) {
+                                    controller.playerOne.get.health
+                                } else {
+                                    "-"
+                                }
+                            }</div>
                         </div>
                         <div class="playerinfo-row">
                             <div>Credits:</div>
-                            <div id="idPlayer1Credits">@{controller.playerOne.get.credits}</div>
+                            <div id="idPlayer1Credits">
+                                @{if (controller.playerOne) {
+                                    controller.playerOne.get.credits
+                                } else {
+                                    "-"
+                                }
+                            }</div>
                         </div>   
                     </div>
                     <div class="playerinfo player2">
                         <div class="playerinfo-row">
                             <div>Name:</div>
-                            <div>@{controller.playerTwo.get.name}</div>
+                            <div id="idPlayer2Name">
+                                @{if (controller.playerTwo) {
+                                    controller.playerTwo.get.name
+                                } else {
+                                    "-"
+                                }
+                            }</div>
                         </div>
                         <div class="playerinfo-row">
                             <div>Base:</div>
-                            <div id="idPlayer2Health">@{controller.playerTwo.get.health}</div>
+                            <div id="idPlayer2Health">
+                                @{if (controller.playerTwo) {
+                                    controller.playerTwo.get.health
+                                } else {
+                                    "-"
+                                }
+                            }</div>
                         </div>
                         <div class="playerinfo-row">
                             <div>Credits:</div>
-                            <div id="idPlayer2Credits">@{controller.playerTwo.get.credits}</div>
+                            <div id="idPlayer2Credits">
+                                @{if (controller.playerTwo) {
+                                    controller.playerTwo.get.credits
+                                } else {
+                                    "-"
+                                }
+                            }</div>
                         </div> 
                     </div>
                 </div>

--- a/app/views/modal.scala.html
+++ b/app/views/modal.scala.html
@@ -7,7 +7,7 @@
 
       <!--Header-->
       <div class="modal-header">
-        <img src="@routes.Assets.versioned("images/board/colloseum.png")" alt="avatar" class="rounded-circle img-responsive">
+        <div class="avatar"></div>
       </div>
       <!--Body-->
       <div class="modal-body text-center mb-1">
@@ -20,7 +20,7 @@
         </div>
 
         <div class="text-center mt-4">
-          <button onclick="onSubmitModal()" class="btn btn-cyan mt-1">OK<i class="fas fa-sign-in ml-1"></i></button>
+          <button onclick="onSubmitModal()" class="btn btn-success">CONNECT<i class="fas fa-sign-in ml-1"></i></button>
         </div>
       </div>
 

--- a/public/javascripts/gladiators.js
+++ b/public/javascripts/gladiators.js
@@ -4,10 +4,10 @@ $(document).ready(function() {
     sendRequest("GET", "/json", {}, function() {
         if (oController.gameState == "NamingPlayerOne") {
             $("#idModal").data("player", "One");
-            openModal("Player 1", "Enter name");
+            openModal("Player 1", "Enter name", "player-one");
         } else if(oController.gameState =="NamingPlayerTwo") {
             $("#idModal").data("player", "Two");
-            openModal("Player 2", "Enter name");
+            openModal("Player 2", "Enter name", "player-two");
         }
         updateGame();
     });
@@ -406,11 +406,14 @@ function animateGladiatorShake(oGladiatorDiv) {
  * Opens the modal
  * @param {String} sHeader - header label
  * @param {String} sInputLabel - input label
+ * @param {String} sClass - class for modal
  */
-function openModal(sHeader, sInputLabel) {
+function openModal(sHeader, sInputLabel, sClass) {
+    removePrefixClass("modal","player-");
+
     $("#idModalHeader").text(sHeader);
     $("#idInputLabel").text(sInputLabel);
-    $("#idModal").modal();
+    $("#idModal").addClass(sClass).modal();
 }
 
 

--- a/public/javascripts/gladiators.js
+++ b/public/javascripts/gladiators.js
@@ -49,8 +49,8 @@ function onClickGladiator(e) {
         sendMoveRequest(oCurrGladiator.x, oCurrGladiator.y, oClickedGladiator.position.x, oClickedGladiator.position.y);
     } else {
         if (oClickedGladiator.moved === false && 
-            ((JSON.stringify(oController.currentPlayer) === JSON.stringify(oController.playerOne) && $(e.target).hasClass("glad-player1"))
-            || (JSON.stringify(oController.currentPlayer) === JSON.stringify(oController.playerTwo) && $(e.target).hasClass("glad-player2")))) {
+            ((oController.currentPlayer.id === oController.playerOne.id && $(e.target).hasClass("glad-player1"))
+            || (oController.currentPlayer.id === oController.playerTwo.id && $(e.target).hasClass("glad-player2")))) {
 
             // save gladiator in cache
             toggleActiveClass(e.target);
@@ -179,7 +179,7 @@ function updatePlayers() {
 function updateCurrentPlayer() {
     if (oController) {
         $(".playerinfo").removeClass("active");
-        if (JSON.stringify(oController.currentPlayer) === JSON.stringify(oController.playerOne)) {
+        if (oController.currentPlayer.id === oController.playerOne.id) {
             $(".player1").addClass("active");
         } else {
             $(".player2").addClass("active");
@@ -217,12 +217,16 @@ function updateBoard() {
                 $("#idTileX"+x+"Y"+y).addClass("tile-" + tile.tileType)
             })
         });
-        oController.playerOne.gladiators.forEach(function(g) {
-            createGladiatorDiv(g, 1);
-        });
-        oController.playerTwo.gladiators.forEach(function(g) {
-            createGladiatorDiv(g, 2);
-        });
+        if (oController.playerOne.gladiators) {
+            oController.playerOne.gladiators.forEach(function(g) {
+                createGladiatorDiv(g, 1);
+            });
+        }
+        if (oController.playerTwo.gladiators) {
+            oController.playerTwo.gladiators.forEach(function(g) {
+                createGladiatorDiv(g, 2);
+            });
+        } 
     }
 }
 

--- a/public/javascripts/gladiators.js
+++ b/public/javascripts/gladiators.js
@@ -464,9 +464,6 @@ function sendRequest(sMethod, sPath, oPayload, fnSuccess) {
         }.bind(this),
         error: function(oResponse) {
             Msg.error(oResponse.responseJSON.message, 2000);
-        },
-        complete: function() {
-            resetCurrGladiator();
         }
     });
 }
@@ -504,6 +501,7 @@ function connectWebSocket() {
                 updatePlayers();
                 $("#idModal").modal("hide");
             case "Turn":
+                updateGame();
                 updateCurrentPlayer();
                 break;
             case "SuccessfullyBoughtGladiator":

--- a/public/javascripts/gladiators.js
+++ b/public/javascripts/gladiators.js
@@ -500,6 +500,7 @@ function connectWebSocket() {
             case "PlayerTwoNamed":
                 updatePlayers();
                 $("#idModal").modal("hide");
+                break;
             case "Turn":
                 updateGame();
                 updateCurrentPlayer();
@@ -526,6 +527,7 @@ function connectWebSocket() {
                 } else {
                     animateValue("idPlayer2Health", oController.playerTwo.health, 1000);
                 }
+                break;
             case "Attacked":
                 let bFound = false,
                     oToGladiator = $("#idGladX" + oEvent.to.x + "Y" + oEvent.to.y);
@@ -545,6 +547,10 @@ function connectWebSocket() {
                     updateHealthBar(oToGladiator, true);
                     setTimeout(function() {oToGladiator.remove()}, 1000); 
                 }
+                break;
+            case "ErrorMessage":
+                Msg.error(oEvent.message, 2000);
+                break;
         }
     }.bind(this);
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -382,6 +382,9 @@ body {
 .modal .modal-header {
   justify-content: center;
 }
+.modal .modal-dialog {
+  top: 30%;
+}
 .modal .avatar {
   height: 5rem;
   width: 5rem;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -379,6 +379,22 @@ body {
   width: 100%;
   height: 100%;
 }
+.modal .modal-header {
+  justify-content: center;
+}
+.modal .avatar {
+  height: 5rem;
+  width: 5rem;
+  border-radius: 10px;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.modal.player-one .avatar {
+  background-image: url("/assets/images/board/temple.png");
+}
+.modal.player-two .avatar {
+  background-image: url("/assets/images/board/colloseum.png");
+}
 #idLogo {
   border: 3px solid lightgrey;
   border-radius: 13px;


### PR DESCRIPTION
I think we will need to update the js code to make this work.
But this way we can separate player-actions and spectators, without too much effort.

Spectators cannot send commands, using the web-socket, as they will get blocked. 
They will still receive all updates by listening to the controller.

Players can only name a player as long as they haven't done so already.
Every command they send to manipulate player-specific data is checked, to see if they are the correct player.

Every registered web-socket will be a player, as long, as the game-state is NamingPlayerOne or NamingPlayerTwo.
But only one web-socket can register per player, this is assured by checking the return type of controller.namePlayer_(), before assigning a player to the WebSocket.

🔥 🚀 